### PR TITLE
Switch to MSYS2 for installing Emacs on MS-Windows in CI (fix for #55)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,8 @@ jobs:
             emacs_version: '27.2'
           - os: macos-latest
             emacs_version: 'snapshot'
-          # Currently disabled as failing for reasons unrelated to Eldev, see issue #55.
-          # - os: windows-latest
-          #   emacs_version: '27.2'
+          - os: windows-latest
+            emacs_version: '27.2'
 
     steps:
     - name: Set up Emacs
@@ -40,9 +39,21 @@ jobs:
 
     - name: Set up Emacs on Windows
       if: startsWith (matrix.os, 'windows')
-      uses: jcs090218/setup-emacs-windows@master
+      # Use MSYS2 as a temporary workaround for issue #55 with Emacs
+      # official MS-Windows prebuilt 27.2 binaries.
+      #
+      # uses: purcell/setup-emacs@master
+      # with:
+      #   version: ${{matrix.emacs_version}}
+      uses: msys2/setup-msys2@v2
       with:
-        version: ${{matrix.emacs_version}}
+        release: false
+        path-type: inherit
+        install: mingw64/mingw-w64-x86_64-emacs
+    - name: Add MSYS2 packages directory to PATH
+      if: startsWith (matrix.os, 'windows')
+      run: |
+        echo "c:/msys64/mingw64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Set up additional packages (Ubuntu)
       if: startsWith (matrix.os, 'ubuntu')


### PR DESCRIPTION
Hi,

could you please consider fix for #55 whereby the Emacs MS-Windows precompiled binaries installed with `purcell/setup-emacs@master` GitHub action used in Eldev CI, ships with a GnuTLS version which is susceptible to a bug with expired issuer certificates.

The solution proposed here is to install Emacs as an msys2 package. msys2 itself is already preinstalled on the GitHub Windows 2019 servers, we just utilize it to install the latest Emacs package and set up the global PATH to point to it with an additional GitHub action.

Once a new binary is available in `purcell/setup-emacs`, we can switch back to that installer. The benefit of `purcell/setup-emacs` over msys2 is that you can specify which version to install, while with msys2 you can only download the latest available precompiled version (which can change without notice, i.e. going from 27.2 to 28.5 once that becomes available), i.e. no fine grain control which exact version/binary is being used.

All test pass now on CI.

Thanks