### PR TITLE
Fix missing `setf` symbol on <24.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        emacs_version: ['24.4', '24.5',
+        emacs_version: ['24.1', '24.4', '24.5',
                         '25.1', '25.2', '25.3',
                         '26.1', '26.2', '26.3',
                         '27.1', '27.2',

--- a/bin/eldev
+++ b/bin/eldev
@@ -34,6 +34,9 @@ export ELDEV_TTY
 
 $ELDEV_EMACS --batch --no-site-file --no-site-lisp                                                     \
              --execute '(let ((eldev--emacs-version (format "%s.%s" emacs-major-version emacs-minor-version))
+      (when (and (= emacs-major-version 24)
+                 (< emacs-minor-version 3))
+        (require '\''cl))
       (eldev--dir           (getenv "ELDEV_DIR"))
       ;; This is intentional.  First, this is in case ELDEV_LOCAL is
       ;; defined, second, this is just Eldev default for packages.

--- a/bin/eldev.bat
+++ b/bin/eldev.bat
@@ -43,6 +43,9 @@ REM the newline variable above MUST be followed by two empty lines.
   ;; so `condition-case-unless-debug'. !NL!^
   (unless (and (fboundp 'version^<=) (version^<= """24.1""" eldev--emacs-version)) !NL!^
     (error """Eldev requires Emacs 24.1 or newer""")) !NL!^
+  (when (and (= emacs-major-version 24) !NL!^
+             (^< emacs-minor-version 3)) !NL!^
+    (require 'cl)) !NL!^
   (setf package-user-dir !NL!^
         (expand-file-name """bootstrap""" !NL!^
                           (expand-file-name eldev--emacs-version !NL!^


### PR DESCRIPTION
```sh
docker run --rm -u 1000:1000 docker.io/silex/emacs:24.1 sh -c 'emacs --batch --eval "(setf)"'
```

vs

```sh
docker run --rm -u 1000:1000 docker.io/silex/emacs:24.1 sh -c "emacs --batch --eval \"(progn (require 'cl) (setf (buffer-name) (buffer-name)))\""
```

and `cl-lib` doesn't exist there yet I presume, so it might trigger a deprecated `cl` message somewhere if `when` isn't adhered to, so I miiight be missing some flag or something here.