### PR TITLE
Bump required Emacs versions to 24.4

### DIFF
--- a/bin/bootstrap.el.part
+++ b/bin/bootstrap.el.part
@@ -7,8 +7,8 @@
   ;; Setting `debug-on-error' would be useful, but it can break many
   ;; `package-*' functions, since those use `with-demoted-errors' and
   ;; so `condition-case-unless-debug'.
-  (unless (and (fboundp 'version<=) (version<= "24.1" eldev--emacs-version))
-    (error "Eldev requires Emacs 24.1 or newer"))
+  (unless (and (fboundp 'version<=) (version<= "24.4" eldev--emacs-version))
+    (error "Eldev requires Emacs 24.4 or newer"))
   (setf package-user-dir
         (expand-file-name "bootstrap"
                           (expand-file-name eldev--emacs-version

--- a/bin/eldev
+++ b/bin/eldev
@@ -41,8 +41,8 @@ $ELDEV_EMACS --batch --no-site-file --no-site-lisp                              
   ;; Setting `debug-on-error'\'' would be useful, but it can break many
   ;; `package-*'\'' functions, since those use `with-demoted-errors'\'' and
   ;; so `condition-case-unless-debug'\''.
-  (unless (and (fboundp '\''version<=) (version<= "24.1" eldev--emacs-version))
-    (error "Eldev requires Emacs 24.1 or newer"))
+  (unless (and (fboundp '\''version<=) (version<= "24.4" eldev--emacs-version))
+    (error "Eldev requires Emacs 24.4 or newer"))
   (setf package-user-dir
         (expand-file-name "bootstrap"
                           (expand-file-name eldev--emacs-version

--- a/bin/eldev.bat
+++ b/bin/eldev.bat
@@ -41,8 +41,8 @@ REM the newline variable above MUST be followed by two empty lines.
   ;; Setting `debug-on-error' would be useful, but it can break many !NL!^
   ;; `package-*' functions, since those use `with-demoted-errors' and !NL!^
   ;; so `condition-case-unless-debug'. !NL!^
-  (unless (and (fboundp 'version^<=) (version^<= """24.1""" eldev--emacs-version)) !NL!^
-    (error """Eldev requires Emacs 24.1 or newer""")) !NL!^
+  (unless (and (fboundp 'version^<=) (version^<= """24.4""" eldev--emacs-version)) !NL!^
+    (error """Eldev requires Emacs 24.4 or newer""")) !NL!^
   (setf package-user-dir !NL!^
         (expand-file-name """bootstrap""" !NL!^
                           (expand-file-name eldev--emacs-version !NL!^

--- a/test/missing-dependency-a/missing-dependency-a.el
+++ b/test/missing-dependency-a/missing-dependency-a.el
@@ -2,7 +2,7 @@
 
 ;; Version: 1.0
 ;; Homepage: https://example.com/
-;; Package-Requires: ((emacs "24.1") (dependency-a "0.1"))
+;; Package-Requires: ((emacs "24.4") (dependency-a "0.1"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
Match the required versions to the documented one.

Closes #108